### PR TITLE
Refactor: Update Label type to string and adapt components

### DIFF
--- a/app/labels/page.tsx
+++ b/app/labels/page.tsx
@@ -4,43 +4,29 @@ import { useState, useEffect } from "react"
 import { useLabels } from "@/hooks/use-labels"
 import { LabelCard } from "@/components/label-card"
 import { Input } from "@/components/ui/input"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Search } from "lucide-react"
-import type { Label } from "@/store/use-store"
+// import type { Label } from "@/store/use-store"; // Label is now string via lib/api.ts
 
 export default function LabelsPage() {
-  const { labels, isLoading } = useLabels()
+  const { labels, isLoading } = useLabels() // useLabels now returns string[]
   const [searchTerm, setSearchTerm] = useState("")
-  const [filteredLabels, setFilteredLabels] = useState<Label[]>([])
-  const [activeCategory, setActiveCategory] = useState<string>("all")
+  const [filteredLabels, setFilteredLabels] = useState<string[]>([])
+  // activeCategory and categories are removed
 
-  // Asegurarnos de que labels sea un array
-  const safeLabels = Array.isArray(labels) ? labels : []
-
-  // Find unique categories
-  const categories = ["all", ...Array.from(new Set(safeLabels.map((label) => label.category)))]
-
-  // Filter labels based on search and category
+  // Filter labels based on search
   useEffect(() => {
     // Asegurarnos de que labels sea un array
     const safeLabels = Array.isArray(labels) ? labels : []
     let filtered = [...safeLabels]
 
     if (searchTerm) {
-      filtered = filtered.filter(
-        (label) =>
-          label.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-          label.description.toLowerCase().includes(searchTerm.toLowerCase()),
-      )
+      filtered = filtered.filter((label) => label.toLowerCase().includes(searchTerm.toLowerCase()))
     }
 
-    if (activeCategory !== "all") {
-      filtered = filtered.filter((label) => label.category === activeCategory)
-    }
-
+    // Category filtering removed
     setFilteredLabels(filtered)
-  }, [labels, searchTerm, activeCategory])
+  }, [labels, searchTerm]) // activeCategory removed from dependencies
 
   return (
     <div className="container py-8">
@@ -57,35 +43,24 @@ export default function LabelsPage() {
         />
       </div>
 
-      <Tabs defaultValue="all" value={activeCategory} onValueChange={setActiveCategory}>
-        <TabsList className="mb-6 flex flex-wrap h-auto">
-          {categories.map((category) => (
-            <TabsTrigger key={category} value={category} className="mb-1">
-              {category === "all" ? "Todas" : category}
-            </TabsTrigger>
+      {/* Tabs component removed */}
+      {isLoading ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Skeleton key={i} className="w-full h-[250px]" />
           ))}
-        </TabsList>
-
-        <TabsContent value={activeCategory} className="mt-0">
-          {isLoading ? (
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {Array.from({ length: 6 }).map((_, i) => (
-                <Skeleton key={i} className="w-full h-[250px]" />
-              ))}
-            </div>
-          ) : filteredLabels.length === 0 ? (
-            <div className="text-center py-8 border rounded-lg">
-              <p className="text-muted-foreground">No se encontraron señas</p>
-            </div>
-          ) : (
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {filteredLabels.map((label) => (
-                <LabelCard key={label.id} label={label} />
-              ))}
-            </div>
-          )}
-        </TabsContent>
-      </Tabs>
+        </div>
+      ) : filteredLabels.length === 0 ? (
+        <div className="text-center py-8 border rounded-lg">
+          <p className="text-muted-foreground">No se encontraron señas</p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {filteredLabels.map((label) => (
+            <LabelCard key={label} label={label} /> // Key updated to label itself
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/app/practice/page.tsx
+++ b/app/practice/page.tsx
@@ -6,11 +6,10 @@ import { CameraModule } from "@/components/camera-module"
 import { PredictionResult } from "@/components/prediction-result"
 import { LabelCard } from "@/components/label-card"
 import { useLabels } from "@/hooks/use-labels"
-import type { Label } from "@/store/use-store"
-import { type PredictionResponse } from "@/lib/api"; // Added import
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+// import type { Label } from "@/store/use-store"; // Label is now string
+import { type PredictionResponse } from "@/lib/api";
 import { Input } from "@/components/ui/input"
-import { Badge } from "@/components/ui/badge"
+// Badge and Tabs are no longer used directly here for categories/difficulty
 import { Skeleton } from "@/components/ui/skeleton"
 import { Search } from "lucide-react"
 
@@ -18,55 +17,45 @@ export default function PracticePage() {
   const searchParams = useSearchParams()
   const router = useRouter()
   const labelId = searchParams.get("label")
-  const { labels, isLoading } = useLabels()
-  const [selectedLabel, setSelectedLabel] = useState<Label | null>(null)
+  const { labels, isLoading } = useLabels() // labels is string[]
+  const [selectedLabel, setSelectedLabel] = useState<string | null>(null) // Updated type
   const [searchTerm, setSearchTerm] = useState("")
-  const [filteredLabels, setFilteredLabels] = useState<Label[]>([])
-  const [activeCategory, setActiveCategory] = useState<string>("all")
+  const [filteredLabels, setFilteredLabels] = useState<string[]>([]) // Updated type
+  // activeCategory and categories removed
   const [predictionResult, setPredictionResult] = useState<PredictionResponse | null>(null)
 
   // Asegurarnos de que labels sea un array
   const safeLabels = Array.isArray(labels) ? labels : []
 
-  // Find unique categories
-  const categories = ["all", ...Array.from(new Set(safeLabels.map((label) => label.category)))]
-
-  // Filter labels based on search and category
+  // Filter labels based on search
   useEffect(() => {
     const safeLabels = Array.isArray(labels) ? labels : []
     let filtered = [...safeLabels]
 
     if (searchTerm) {
-      filtered = filtered.filter(
-        (label) =>
-          label.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-          label.description.toLowerCase().includes(searchTerm.toLowerCase()),
-      )
+      filtered = filtered.filter((label) => label.toLowerCase().includes(searchTerm.toLowerCase()))
     }
 
-    if (activeCategory !== "all") {
-      filtered = filtered.filter((label) => label.category === activeCategory)
-    }
-
+    // Category filtering removed
     setFilteredLabels(filtered)
-  }, [labels, searchTerm, activeCategory])
+  }, [labels, searchTerm]) // activeCategory removed from dependencies
 
   // Set selected label from URL param
   useEffect(() => {
     const safeLabels = Array.isArray(labels) ? labels : []
     if (labelId && safeLabels.length > 0) {
-      const label = safeLabels.find((l) => l.id === labelId)
+      const label = safeLabels.find((l) => l === labelId) // Updated find logic
       if (label) {
         setSelectedLabel(label)
       }
     }
   }, [labelId, labels])
 
-  const handleLabelSelect = (label: Label) => {
+  const handleLabelSelect = (label: string) => { // Updated type
     setSelectedLabel(label)
     setPredictionResult(null)
     // Update URL to reflect selected label
-    router.push(`/practice?label=${label.id}`)
+    router.push(`/practice?label=${label}`) // Updated URL param
   }
 
   const handlePredictionComplete = (result: PredictionResponse) => {
@@ -86,20 +75,20 @@ export default function PracticePage() {
     if (!selectedLabel) return
 
     const safeLabels = Array.isArray(labels) ? labels : []
-    const currentIndex = safeLabels.findIndex((label) => label.id === selectedLabel.id)
+    const currentIndex = safeLabels.findIndex((l) => l === selectedLabel) // Updated findIndex logic
 
     if (currentIndex !== -1 && currentIndex < safeLabels.length - 1) {
       const nextLabel = safeLabels[currentIndex + 1]
       setSelectedLabel(nextLabel)
       setPredictionResult(null)
-      router.push(`/practice?label=${nextLabel.id}`)
+      router.push(`/practice?label=${nextLabel}`) // Updated URL param
     } else {
       // If it's the last lesson, go to the first one or show completion message
       const firstLabel = safeLabels[0]
       if (firstLabel) {
         setSelectedLabel(firstLabel)
         setPredictionResult(null)
-        router.push(`/practice?label=${firstLabel.id}`)
+        router.push(`/practice?label=${firstLabel}`) // Updated URL param
       }
     }
   }
@@ -123,40 +112,29 @@ export default function PracticePage() {
                 />
               </div>
 
-              <Tabs defaultValue="all" value={activeCategory} onValueChange={setActiveCategory}>
-                <TabsList className="mb-4 flex flex-wrap h-auto">
-                  {categories.map((category, index) => (
-                    <TabsTrigger key={`${category}-${index}`} value={category} className="mb-1">
-                      {category === "all" ? "Todas" : category}
-                    </TabsTrigger>
+              {/* Tabs for category filtering removed */}
+              {isLoading ? (
+                <div className="space-y-4">
+                  {Array.from({ length: 3 }).map((_, i) => (
+                    <Skeleton key={i} className="w-full h-[200px]" />
                   ))}
-                </TabsList>
-
-                <TabsContent value={activeCategory} className="mt-0">
-                  {isLoading ? (
-                    <div className="space-y-4">
-                      {Array.from({ length: 3 }).map((_, i) => (
-                        <Skeleton key={i} className="w-full h-[200px]" />
-                      ))}
-                    </div>
-                  ) : filteredLabels.length === 0 ? (
-                    <div className="text-center py-8 border rounded-lg">
-                      <p className="text-muted-foreground">No se encontraron señas</p>
-                    </div>
-                  ) : (
-                    <div className="space-y-4 max-h-[600px] overflow-y-auto pr-2">
-                      {filteredLabels.map((label) => (
-                        <LabelCard
-                          key={label.id}
-                          label={label}
-                          onSelect={() => handleLabelSelect(label)}
-                          isSelected={selectedLabel?.id === label.id}
-                        />
-                      ))}
-                    </div>
-                  )}
-                </TabsContent>
-              </Tabs>
+                </div>
+              ) : filteredLabels.length === 0 ? (
+                <div className="text-center py-8 border rounded-lg">
+                  <p className="text-muted-foreground">No se encontraron señas</p>
+                </div>
+              ) : (
+                <div className="space-y-4 max-h-[600px] overflow-y-auto pr-2">
+                  {filteredLabels.map((label) => (
+                    <LabelCard
+                      key={label} // Updated key
+                      label={label} // label is now string
+                      onSelect={() => handleLabelSelect(label)}
+                      isSelected={selectedLabel === label} // Updated isSelected logic
+                    />
+                  ))}
+                </div>
+              )}
             </div>
           </div>
 
@@ -165,39 +143,25 @@ export default function PracticePage() {
             <div>
               <h2 className="text-2xl font-bold mb-4">Practica la seña</h2>
 
-              {selectedLabel ? (
+              {selectedLabel ? ( // selectedLabel is now string | null
                 <div className="space-y-6">
                   <div className="flex items-center gap-3 mb-6">
-                    <h3 className="text-xl font-medium">{selectedLabel.name}</h3>
-                    <Badge variant="outline">{selectedLabel.category}</Badge>
-                    <Badge
-                      className={
-                        selectedLabel.difficulty === "beginner"
-                          ? "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300"
-                          : selectedLabel.difficulty === "intermediate"
-                            ? "bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-300"
-                            : "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300"
-                      }
-                    >
-                      {selectedLabel.difficulty === "beginner"
-                        ? "Principiante"
-                        : selectedLabel.difficulty === "intermediate"
-                          ? "Intermedio"
-                          : "Avanzado"}
-                    </Badge>
+                    <h3 className="text-xl font-medium">{selectedLabel}</h3> {/* Display selectedLabel directly */}
+                    {/* Badges for category and difficulty removed */}
                   </div>
 
                   {predictionResult ? (
                     <div className="flex justify-center">
                       <PredictionResult
                         result={predictionResult}
-                        expectedLabel={selectedLabel.name}
+                        expectedLabel={selectedLabel} // Pass selectedLabel string
                         onClose={handleClosePrediction}
                         onRepeat={handleRepeat}
                         onNextLesson={handleNextLesson}
                       />
                     </div>
                   ) : (
+                    // CameraModule expects selectedLabel: string, which is now correct
                     <CameraModule selectedLabel={selectedLabel} onPredictionComplete={handlePredictionComplete} />
                   )}
                 </div>

--- a/components/label-card.tsx
+++ b/components/label-card.tsx
@@ -1,25 +1,19 @@
 "use client"
 
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import type { Label } from "@/store/use-store"
+// import type { Label } from "@/store/use-store" // Label is now string
 import { BookOpen, BarChart3 } from "lucide-react"
 import Link from "next/link"
 
 interface LabelCardProps {
-  label: Label
+  label: string // Updated to string
   onSelect?: () => void
   isSelected?: boolean
 }
 
 export function LabelCard({ label, onSelect, isSelected = false }: LabelCardProps) {
-  const difficultyColor = {
-    beginner: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300",
-    intermediate: "bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-300",
-    advanced: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300",
-  }
-
   // Función para generar un color de fondo basado en el nombre de la etiqueta
   // para simular diferentes imágenes de ejemplo
   const getBackgroundColor = (name: string) => {
@@ -39,28 +33,19 @@ export function LabelCard({ label, onSelect, isSelected = false }: LabelCardProp
     <Card className={`transition-all ${isSelected ? "ring-2 ring-primary" : ""}`}>
       <CardHeader className="pb-2">
         <div className="flex justify-between items-start">
-          <CardTitle className="text-lg">{label.name}</CardTitle>
-          <Badge className={difficultyColor[label.difficulty]}>
-            {label.difficulty === "beginner"
-              ? "Principiante"
-              : label.difficulty === "intermediate"
-                ? "Intermedio"
-                : "Avanzado"}
-          </Badge>
+          <CardTitle className="text-lg">{label}</CardTitle>
+          {/* Difficulty Badge Removed */}
         </div>
-        <CardDescription>{label.description}</CardDescription>
+        {/* CardDescription Removed */}
       </CardHeader>
       <CardContent>
-        <Badge variant="outline" className="mb-2">
-          {label.category}
-        </Badge>
-
+        {/* Category Badge Removed */}
         <div
           className="w-full aspect-video rounded-md flex items-center justify-center mt-2 overflow-hidden"
-          style={{ backgroundColor: getBackgroundColor(label.name) }}
+          style={{ backgroundColor: getBackgroundColor(label) }}
         >
           <div className="text-center p-4">
-            <p className="font-medium text-gray-700">Ejemplo: {label.name}</p>
+            <p className="font-medium text-gray-700">Ejemplo: {label}</p>
             <p className="text-sm text-gray-600 mt-1">Imagen ilustrativa</p>
           </div>
         </div>
@@ -73,13 +58,13 @@ export function LabelCard({ label, onSelect, isSelected = false }: LabelCardProp
         ) : (
           <>
             <Button variant="outline" size="sm" asChild className="flex-1">
-              <Link href={`/labels/${label.id}`}>
+              <Link href={`/labels/${label}`}>
                 <BookOpen className="h-4 w-4 mr-2" />
                 Detalles
               </Link>
             </Button>
             <Button variant="outline" size="sm" asChild className="flex-1">
-              <Link href={`/practice?label=${label.id}`}>
+              <Link href={`/practice?label=${label}`}>
                 <BarChart3 className="h-4 w-4 mr-2" />
                 Practicar
               </Link>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -30,14 +30,7 @@ export interface PredictionResponse {
   average_confidence?: number
 }
 
-export interface Label {
-  id: string
-  name: string
-  description: string
-  category: string
-  difficulty: "beginner" | "intermediate" | "advanced"
-  sequence?: any[]; // Optional: A sequence associated with the label, structure might vary or be undefined.
-}
+export type Label = string;
 
 export interface PredictionRecord {
   id: string
@@ -80,90 +73,18 @@ export interface GlobalStats {
 
 // Datos dummy para fallback
 const DUMMY_LABELS: Label[] = [
-  {
-    id: "1",
-    name: "Tengo fiebre",
-    description: "Señas para indicar que tienes fiebre",
-    category: "Síntomas",
-    difficulty: "beginner",
-  },
-  {
-    id: "2",
-    name: "Me duele la cabeza",
-    description: "Señas para indicar dolor de cabeza",
-    category: "Síntomas",
-    difficulty: "beginner",
-  },
-  {
-    id: "3",
-    name: "Tengo tos",
-    description: "Señas para indicar que tienes tos",
-    category: "Síntomas",
-    difficulty: "beginner",
-  },
-  {
-    id: "4",
-    name: "Necesito medicamentos",
-    description: "Señas para solicitar medicamentos",
-    category: "Solicitudes",
-    difficulty: "intermediate",
-  },
-  {
-    id: "5",
-    name: "Tengo alergia",
-    description: "Señas para indicar que tienes una alergia",
-    category: "Síntomas",
-    difficulty: "intermediate",
-  },
-  {
-    id: "6",
-    name: "Me siento mareado",
-    description: "Señas para indicar mareo o vértigo",
-    category: "Síntomas",
-    difficulty: "intermediate",
-  },
-  {
-    id: "7",
-    name: "Necesito un intérprete",
-    description: "Señas para solicitar un intérprete",
-    category: "Solicitudes",
-    difficulty: "beginner",
-  },
-  {
-    id: "8",
-    name: "Tengo diabetes",
-    description: "Señas para comunicar que tienes diabetes",
-    category: "Condiciones",
-    difficulty: "advanced",
-  },
-  {
-    id: "9",
-    name: "Soy alérgico a la penicilina",
-    description: "Señas para comunicar alergia a medicamentos",
-    category: "Condiciones",
-    difficulty: "advanced",
-  },
-  {
-    id: "10",
-    name: "Necesito ayuda",
-    description: "Señas para solicitar asistencia general",
-    category: "Solicitudes",
-    difficulty: "beginner",
-  },
-  {
-    id: "11",
-    name: "Tengo dolor de estómago",
-    description: "Señas para indicar dolor abdominal",
-    category: "Síntomas",
-    difficulty: "intermediate",
-  },
-  {
-    id: "12",
-    name: "Estoy embarazada",
-    description: "Señas para comunicar embarazo",
-    category: "Condiciones",
-    difficulty: "intermediate",
-  },
+  "Tengo fiebre",
+  "Me duele la cabeza",
+  "Tengo tos",
+  "Necesito medicamentos",
+  "Tengo alergia",
+  "Me siento mareado",
+  "Necesito un intérprete",
+  "Tengo diabetes",
+  "Soy alérgico a la penicilina",
+  "Necesito ayuda",
+  "Tengo dolor de estómago",
+  "Estoy embarazada",
 ]
 
 // Función helper para generar datos dummy de records
@@ -175,7 +96,7 @@ const generateDummyRecords = (count = 50): PredictionRecord[] => {
     date.setDate(date.getDate() - daysAgo)
     date.setHours(date.getHours() - hoursAgo)
 
-    const expectedLabel = DUMMY_LABELS[Math.floor(Math.random() * DUMMY_LABELS.length)].name
+    const expectedLabel = DUMMY_LABELS[Math.floor(Math.random() * DUMMY_LABELS.length)]
     const evaluationRandom = Math.random()
 
     let evaluation: "correct" | "doubtful" | "incorrect"
@@ -194,7 +115,7 @@ const generateDummyRecords = (count = 50): PredictionRecord[] => {
       evaluation = "incorrect"
       let incorrectLabel
       do {
-        incorrectLabel = DUMMY_LABELS[Math.floor(Math.random() * DUMMY_LABELS.length)].name
+        incorrectLabel = DUMMY_LABELS[Math.floor(Math.random() * DUMMY_LABELS.length)]
       } while (incorrectLabel === expectedLabel)
       predictedLabel = incorrectLabel
       confidence = 0.3 + Math.random() * 0.2
@@ -222,14 +143,14 @@ const generateDummyRecords = (count = 50): PredictionRecord[] => {
 
 // Función helper para generar datos dummy de progreso
 const generateDummyProgress = (): ProgressData[] => {
-  return DUMMY_LABELS.map((label) => {
+  return DUMMY_LABELS.map((label_name) => {
     const totalAttempts = Math.floor(Math.random() * 20) + 1
     const correctAttempts = Math.floor(totalAttempts * (0.3 + Math.random() * 0.5))
     const doubtfulAttempts = Math.floor((totalAttempts - correctAttempts) * 0.6)
     const incorrectAttempts = totalAttempts - correctAttempts - doubtfulAttempts
 
     return {
-      label_name: label.name,
+      label_name: label_name,
       total_attempts: totalAttempts,
       correct_attempts: correctAttempts,
       doubtful_attempts: doubtfulAttempts,
@@ -326,7 +247,7 @@ class ApiService {
       confidence = 0.5 + Math.random() * 0.25
     } else {
       evaluation = "incorrect"
-      const possibleLabels = DUMMY_LABELS.map((l) => l.name).filter((name) => name !== data.expected_label)
+      const possibleLabels = DUMMY_LABELS.filter((name) => name !== data.expected_label)
       predictedLabel = possibleLabels[Math.floor(Math.random() * possibleLabels.length)]
       confidence = 0.3 + Math.random() * 0.2
     }


### PR DESCRIPTION
- I changed the Label type from an object to a string in `lib/api.ts`.
- I updated `DUMMY_LABELS` to be an array of strings and modified consuming functions.
- I refactored `LabelCard` to expect a string label and removed usage of object properties (description, category, difficulty).
- I updated `app/labels/page.tsx` to remove category filtering and adapt search for string labels.
- I updated `app/practice/page.tsx` to handle string labels for selection, display, navigation, and interaction with CameraModule/PredictionResult.
- I ensured that components relying on the Label type now correctly use it as a string, addressing the issue of the backend returning a flat array of strings for labels.