### PR TITLE
Use Render backend for API

### DIFF
--- a/components/api-status.tsx
+++ b/components/api-status.tsx
@@ -37,12 +37,11 @@ export function ApiStatus() {
 
   const checkApiStatus = async () => {
     try {
-      const apiUrl = process.env.NEXT_PUBLIC_API_URL || "https://7a96-2800-200-fdd0-2611-f82b-705-e365-f53.ngrok-free.app"
+      const apiUrl = process.env.NEXT_PUBLIC_API_URL || "https://machinelear.onrender.com"
       const response = await fetch(`${apiUrl}/health`, {
         method: "GET",
         headers: {
           "Content-Type": "application/json",
-          "ngrok-skip-browser-warning": "true", // Evita advertencias de ngrok
         },
         signal: AbortSignal.timeout(5000), // 5 second timeout
       })

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -163,7 +163,7 @@ const generateDummyProgress = (): ProgressData[] => {
   }).filter((p) => p.total_attempts > 0)
 }
 
-// Headers estándar para todas las llamadas API (incluyendo ngrok)
+// Headers estándar para todas las llamadas API
 const getApiHeaders = (additionalHeaders: Record<string, string> = {}): Record<string, string> => {
   return {
     "Content-Type": "application/json", // Still needed for POST/PUT to our /api routes

--- a/lib/server-config.ts
+++ b/lib/server-config.ts
@@ -1,0 +1,1 @@
+export const BACKEND_BASE_URL = process.env.BACKEND_URL || "https://machinelear.onrender.com";

--- a/pages/api/health.ts
+++ b/pages/api/health.ts
@@ -6,20 +6,15 @@
  * It includes specific handling for potentially non-JSON health check responses.
  */
 import type { NextApiRequest, NextApiResponse } from "next";
-
-// TODO: Consider moving this to an environment variable for the Next.js server
-const NGROK_BACKEND_URL = "https://7a96-2800-200-fdd0-2611-f82b-705-e365-f53.ngrok-free.app";
+import { BACKEND_BASE_URL } from "@/lib/server-config";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'GET') {
     try {
-      const backendUrl = `${NGROK_BACKEND_URL}/health`;
+      const backendUrl = `${BACKEND_BASE_URL}/health`;
 
       const backendRes = await fetch(backendUrl, {
         method: "GET",
-        headers: {
-          "ngrok-skip-browser-warning": "true",
-        },
       });
 
       // For health checks, sometimes the status code is all that matters.

--- a/pages/api/labels.ts
+++ b/pages/api/labels.ts
@@ -5,19 +5,13 @@
  * and securely communicate with the backend services.
  */
 import type { NextApiRequest, NextApiResponse } from "next";
-
-// TODO: Consider moving this to an environment variable for the Next.js server
-const NGROK_BACKEND_URL = "https://7a96-2800-200-fdd0-2611-f82b-705-e365-f53.ngrok-free.app";
+import { BACKEND_BASE_URL } from "@/lib/server-config";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'GET') {
     try {
-      const backendRes = await fetch(`${NGROK_BACKEND_URL}/labels`, {
+      const backendRes = await fetch(`${BACKEND_BASE_URL}/labels`, {
         method: "GET",
-        headers: {
-          "ngrok-skip-browser-warning": "true",
-          // Add any other headers your backend might expect for GET requests, if any
-        },
       });
 
       // It's good practice to check if the backend response was successful

--- a/pages/api/predict.ts
+++ b/pages/api/predict.ts
@@ -6,17 +6,15 @@
  */
 import type { NextApiRequest, NextApiResponse } from "next";
 
-// TODO: Consider moving this to an environment variable for the Next.js server
-const NGROK_BACKEND_URL = "https://7a96-2800-200-fdd0-2611-f82b-705-e365-f53.ngrok-free.app";
+import { BACKEND_BASE_URL } from "@/lib/server-config";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'POST') {
     try {
-      const backendRes = await fetch(`${NGROK_BACKEND_URL}/predict`, {
+      const backendRes = await fetch(`${BACKEND_BASE_URL}/predict`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "ngrok-skip-browser-warning": "true",
           // Potentially forward other relevant headers from req.headers if needed
         },
         body: JSON.stringify(req.body), // req.body is already parsed by Next.js

--- a/pages/api/progress.ts
+++ b/pages/api/progress.ts
@@ -6,24 +6,19 @@
  * and securely communicate with the backend services.
  */
 import type { NextApiRequest, NextApiResponse } from "next";
-
-// TODO: Consider moving this to an environment variable for the Next.js server
-const NGROK_BACKEND_URL = "https://7a96-2800-200-fdd0-2611-f82b-705-e365-f53.ngrok-free.app";
+import { BACKEND_BASE_URL } from "@/lib/server-config";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'GET') {
     try {
       const { nickname } = req.query;
       
-      const backendUrl = new URL(`${NGROK_BACKEND_URL}/progress`);
+      const backendUrl = new URL(`${BACKEND_BASE_URL}/progress`);
       if (nickname) backendUrl.searchParams.append("nickname", Array.isArray(nickname) ? nickname[0] : nickname);
       // Add other query parameters if the backend /progress endpoint expects them
 
       const backendRes = await fetch(backendUrl.toString(), {
         method: "GET",
-        headers: {
-          "ngrok-skip-browser-warning": "true",
-        },
       });
 
       if (!backendRes.ok) {

--- a/pages/api/records.ts
+++ b/pages/api/records.ts
@@ -6,9 +6,7 @@
  * and securely communicate with the backend services.
  */
 import type { NextApiRequest, NextApiResponse } from "next";
-
-// TODO: Consider moving this to an environment variable for the Next.js server
-const NGROK_BACKEND_URL = "https://7a96-2800-200-fdd0-2611-f82b-705-e365-f53.ngrok-free.app";
+import { BACKEND_BASE_URL } from "@/lib/server-config";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'GET') {
@@ -17,16 +15,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       const { nickname, page, limit } = req.query;
       
       // Construct the URL for the backend, forwarding query parameters
-      const backendUrl = new URL(`${NGROK_BACKEND_URL}/records`);
+      const backendUrl = new URL(`${BACKEND_BASE_URL}/records`);
       if (nickname) backendUrl.searchParams.append("nickname", Array.isArray(nickname) ? nickname[0] : nickname);
       if (page) backendUrl.searchParams.append("page", Array.isArray(page) ? page[0] : page);
       if (limit) backendUrl.searchParams.append("limit", Array.isArray(limit) ? limit[0] : limit);
 
       const backendRes = await fetch(backendUrl.toString(), {
         method: "GET",
-        headers: {
-          "ngrok-skip-browser-warning": "true",
-        },
       });
 
       if (!backendRes.ok) {

--- a/pages/api/stats/global_distribution.ts
+++ b/pages/api/stats/global_distribution.ts
@@ -5,21 +5,16 @@
  * and securely communicate with the backend services.
  */
 import type { NextApiRequest, NextApiResponse } from "next";
-
-// TODO: Consider moving this to an environment variable for the Next.js server
-const NGROK_BACKEND_URL = "https://7a96-2800-200-fdd0-2611-f82b-705-e365-f53.ngrok-free.app";
+import { BACKEND_BASE_URL } from "@/lib/server-config";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'GET') {
     try {
       // This endpoint does not seem to require query parameters from the client.
-      const backendUrl = `${NGROK_BACKEND_URL}/stats/global_distribution`;
+      const backendUrl = `${BACKEND_BASE_URL}/stats/global_distribution`;
 
       const backendRes = await fetch(backendUrl, {
         method: "GET",
-        headers: {
-          "ngrok-skip-browser-warning": "true",
-        },
       });
 
       if (!backendRes.ok) {


### PR DESCRIPTION
## Summary
- connect API proxy routes to `https://machinelear.onrender.com`
- centralize backend base URL in `lib/server-config`
- update API status component default URL

## Testing
- `npm install` *(fails: unable to resolve dependency tree)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68488cc79f70832f840a53920f09a228