### PR TITLE
Fix safe length handling

### DIFF
--- a/app/labels/[id]/page.tsx
+++ b/app/labels/[id]/page.tsx
@@ -10,6 +10,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { ArrowLeft, Play } from "lucide-react"
 import Link from "next/link"
 import type { Label } from "@/lib/api"
+import { safeLength } from "@/lib/utils"
 
 const DEFAULT_LABEL: Label = {
   id: "",
@@ -29,7 +30,7 @@ export default function LabelDetailPage() {
   const safeLabels = useMemo(() => (Array.isArray(labels) ? labels : []), [labels])
 
   useEffect(() => {
-    if (safeLabels.length > 0 && params.id) {
+    if (safeLength(safeLabels) > 0 && params.id) {
       const foundLabel = safeLabels.find((l) => l.id === params.id)
       setLabel(foundLabel ?? DEFAULT_LABEL)
     }

--- a/app/labels/page.tsx
+++ b/app/labels/page.tsx
@@ -7,6 +7,7 @@ import type { Label } from "@/lib/api"
 import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Search } from "lucide-react"
+import { safeLength } from "@/lib/utils"
 
 export default function LabelsPage() {
   const { labels, isLoading } = useLabels()
@@ -52,7 +53,7 @@ export default function LabelsPage() {
             <Skeleton key={i} className="w-full h-[250px]" />
           ))}
         </div>
-      ) : filteredLabels.length === 0 ? (
+      ) : safeLength(filteredLabels) === 0 ? (
         <div className="text-center py-8 border rounded-lg">
           <p className="text-muted-foreground">No se encontraron señas</p>
         </div>

--- a/app/practice/page.tsx
+++ b/app/practice/page.tsx
@@ -11,6 +11,7 @@ import { Input } from "@/components/ui/input"
 // Badge and Tabs are no longer used directly here for categories/difficulty
 import { Skeleton } from "@/components/ui/skeleton"
 import { Search } from "lucide-react"
+import { safeLength } from "@/lib/utils"
 
 export default function PracticePage() {
   const searchParams = useSearchParams()
@@ -44,7 +45,7 @@ export default function PracticePage() {
   // Set selected label from URL param
   useEffect(() => {
     const safeLabels = Array.isArray(labels) ? labels : []
-    if (labelId && safeLabels.length > 0) {
+    if (labelId && safeLength(safeLabels) > 0) {
       const label = safeLabels.find((l) => l.id === labelId)
       if (label) {
         setSelectedLabel(label)
@@ -77,7 +78,7 @@ export default function PracticePage() {
     const safeLabels = Array.isArray(labels) ? labels : []
     const currentIndex = safeLabels.findIndex((l) => l.id === selectedLabel.id)
 
-    if (currentIndex !== -1 && currentIndex < safeLabels.length - 1) {
+    if (currentIndex !== -1 && currentIndex < safeLength(safeLabels) - 1) {
       const nextLabel = safeLabels[currentIndex + 1]
       setSelectedLabel(nextLabel)
       setPredictionResult(null)
@@ -119,7 +120,7 @@ export default function PracticePage() {
                     <Skeleton key={i} className="w-full h-[200px]" />
                   ))}
                 </div>
-              ) : filteredLabels.length === 0 ? (
+              ) : safeLength(filteredLabels) === 0 ? (
                 <div className="text-center py-8 border rounded-lg">
                   <p className="text-muted-foreground">No se encontraron señas</p>
                 </div>

--- a/app/progress/page.tsx
+++ b/app/progress/page.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Skeleton } from "@/components/ui/skeleton"
 import { PieChart, Pie, Cell, ResponsiveContainer, Legend, Tooltip } from "recharts"
+import { safeLength } from "@/lib/utils"
 
 export default function ProgressPage() {
   const { allRecords } = useRecords()
@@ -19,10 +20,10 @@ export default function ProgressPage() {
   const safeLabels = Array.isArray(labels) ? labels : []
 
   // Calculate statistics from records (fallback si no hay progressData de la API)
-  const totalAttempts = safeRecords.length
-  const correctCount = safeRecords.filter((r) => r.evaluation === "correct").length
-  const doubtfulCount = safeRecords.filter((r) => r.evaluation === "doubtful").length
-  const incorrectCount = safeRecords.filter((r) => r.evaluation === "incorrect").length
+  const totalAttempts = safeLength(safeRecords)
+  const correctCount = safeLength(safeRecords.filter((r) => r.evaluation === "correct"))
+  const doubtfulCount = safeLength(safeRecords.filter((r) => r.evaluation === "doubtful"))
+  const incorrectCount = safeLength(safeRecords.filter((r) => r.evaluation === "incorrect"))
 
   const correctPercentage = totalAttempts > 0 ? Math.round((correctCount / totalAttempts) * 100) : 0
   const doubtfulPercentage = totalAttempts > 0 ? Math.round((doubtfulCount / totalAttempts) * 100) : 0
@@ -46,7 +47,7 @@ export default function ProgressPage() {
   // Calculate statistics by label usando progressData de la API si está disponible
   let labelStats: any[] = []
 
-  if (progressData.length > 0) {
+  if (safeLength(progressData) > 0) {
     // Usar datos de la API
     labelStats = progressData.map((progress) => ({
       id: progress.label_name,
@@ -61,8 +62,8 @@ export default function ProgressPage() {
     labelStats = safeLabels
       .map((label) => {
         const labelRecords = safeRecords.filter((r) => r.expected_label === label.name)
-        const total = labelRecords.length
-        const correct = labelRecords.filter((r) => r.evaluation === "correct").length
+        const total = safeLength(labelRecords)
+        const correct = safeLength(labelRecords.filter((r) => r.evaluation === "correct"))
         const percentage = total > 0 ? Math.round((correct / total) * 100) : 0
 
         return {
@@ -71,7 +72,7 @@ export default function ProgressPage() {
           total,
           correct,
           percentage,
-          category: label.category,
+          category: label.category || "Sin categoría",
         }
       })
       .filter((stat) => stat.total > 0)
@@ -81,7 +82,7 @@ export default function ProgressPage() {
   const sortedLabelStats = [...labelStats].sort((a, b) => b.total - a.total)
 
   // Calcular número de señas practicadas
-  const practicesSignsCount = labelStats.length
+  const practicesSignsCount = safeLength(labelStats)
 
   return (
     <div className="min-h-screen bg-background">
@@ -185,7 +186,7 @@ export default function ProgressPage() {
           <CardHeader>
             <CardTitle>Progreso por seña</CardTitle>
             <CardDescription>
-              {progressData.length > 0
+              {safeLength(progressData) > 0
                 ? "Estadísticas detalladas desde la API por cada seña practicada"
                 : "Estadísticas calculadas localmente por cada seña practicada"}
             </CardDescription>
@@ -197,7 +198,7 @@ export default function ProgressPage() {
                   <Skeleton key={i} className="h-16 w-full" />
                 ))}
               </div>
-            ) : sortedLabelStats.length > 0 ? (
+            ) : safeLength(sortedLabelStats) > 0 ? (
               <Tabs defaultValue="most-practiced">
                 <TabsList className="mb-4">
                   <TabsTrigger value="most-practiced">Más practicadas</TabsTrigger>

--- a/components/animated-cards.tsx
+++ b/components/animated-cards.tsx
@@ -16,17 +16,18 @@ export function AnimatedCards({ className, children, interval = 3000, direction 
   const [activeIndex, setActiveIndex] = useState(0)
   const [isAnimating, setIsAnimating] = useState(false)
   const timerRef = useRef<NodeJS.Timeout | null>(null)
+  const childArray = React.Children.toArray(children)
 
   const nextCard = useCallback(() => {
     if (isAnimating) return
 
     setIsAnimating(true)
-    setActiveIndex((prev) => (prev + 1) % children.length)
+    setActiveIndex((prev) => (prev + 1) % childArray.length)
 
     setTimeout(() => {
       setIsAnimating(false)
     }, 600) // Match this with the CSS transition duration
-  }, [isAnimating, children.length])
+  }, [isAnimating, childArray.length])
 
   useEffect(() => {
     timerRef.current = setInterval(nextCard, interval)
@@ -41,7 +42,7 @@ export function AnimatedCards({ className, children, interval = 3000, direction 
   const getCardClassName = (index: number) => {
     if (index === activeIndex) {
       return "opacity-100 scale-100 z-20"
-    } else if (index === activeIndex + 1 || (activeIndex === children.length - 1 && index === 0)) {
+    } else if (index === activeIndex + 1 || (activeIndex === childArray.length - 1 && index === 0)) {
       return direction === "horizontal"
         ? "opacity-70 scale-95 translate-x-[40%] z-10"
         : "opacity-70 scale-95 translate-y-[40%] z-10"
@@ -54,7 +55,7 @@ export function AnimatedCards({ className, children, interval = 3000, direction 
 
   return (
     <div className={cn("relative w-full h-full", className)}>
-      {children.map((child, index) => (
+      {childArray.map((child, index) => (
         <div
           key={index}
           className={cn("absolute inset-0 transition-all duration-600 ease-in-out", getCardClassName(index))}
@@ -65,7 +66,7 @@ export function AnimatedCards({ className, children, interval = 3000, direction 
       ))}
 
       <div className="absolute bottom-4 left-1/2 transform -translate-x-1/2 flex space-x-2">
-        {children.map((_, index) => (
+        {childArray.map((_, index) => (
           <button
             key={index}
             className={cn("w-2 h-2 rounded-full transition-all", index === activeIndex ? "bg-primary w-4" : "bg-muted")}

--- a/components/floating-icons.tsx
+++ b/components/floating-icons.tsx
@@ -41,7 +41,7 @@ export function FloatingIcons({
   const animationRef = useRef<number | null>(null)
 
   useEffect(() => {
-    if (!containerRef.current || icons.length === 0) return
+    if (!containerRef.current || !Array.isArray(icons) || icons.length === 0) return
 
     const { width, height } = containerRef.current.getBoundingClientRect()
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,9 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+// Devuelve la longitud de un array o string de forma segura
+// evitando errores si el valor es undefined o null
+export function safeLength(value?: { length: number } | string | any[]): number {
+  return value?.length ?? 0
+}


### PR DESCRIPTION
## Summary
- add `safeLength` utility
- guard `.length` checks in practice, labels, and progress pages
- make animated cards and floating icons safer

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a0721f1a4832f996797c008213eff