### PR TITLE
Fix color generator crash on missing name

### DIFF
--- a/app/labels/[id]/page.tsx
+++ b/app/labels/[id]/page.tsx
@@ -10,7 +10,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { ArrowLeft, Play } from "lucide-react"
 import Link from "next/link"
 import type { Label } from "@/lib/api"
-import { safeLength } from "@/lib/utils"
+import { safeLength, generateColorFromName } from "@/lib/utils"
 
 const DEFAULT_LABEL: Label = {
   id: "",
@@ -36,18 +36,6 @@ export default function LabelDetailPage() {
     }
   }, [safeLabels, params.id])
 
-  // Función para generar un color de fondo basado en el nombre de la etiqueta
-  const getBackgroundColor = (name: string) => {
-    if (!name) return "hsl(210, 70%, 85%)"
-
-    let hash = 0
-    for (let i = 0; i < name.length; i++) {
-      hash = name.charCodeAt(i) + ((hash << 5) - hash)
-    }
-
-    const hue = hash % 360
-    return `hsl(${hue}, 70%, 85%)`
-  }
 
   const difficultyText = {
     beginner: "Principiante",
@@ -123,7 +111,7 @@ export default function LabelDetailPage() {
           <CardContent className="p-0">
             <div
               className="w-full aspect-video flex items-center justify-center"
-              style={{ backgroundColor: getBackgroundColor(label.name) }}
+              style={{ backgroundColor: generateColorFromName(label?.name) }}
             >
               <div className="text-center p-6">
                 <h2 className="text-2xl font-bold text-gray-800 mb-2">{label.name}</h2>

--- a/components/label-card.tsx
+++ b/components/label-card.tsx
@@ -3,6 +3,7 @@
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import type { Label } from "@/lib/api"
+import { generateColorFromName } from "@/lib/utils"
 import { BookOpen, BarChart3 } from "lucide-react"
 import Link from "next/link"
 
@@ -13,20 +14,6 @@ interface LabelCardProps {
 }
 
 export function LabelCard({ label, onSelect, isSelected = false }: LabelCardProps) {
-  // Función para generar un color de fondo basado en el nombre de la etiqueta
-  // para simular diferentes imágenes de ejemplo
-  const getBackgroundColor = (name: string) => {
-    // Convertir el nombre a un número hash simple
-    let hash = 0
-    for (let i = 0; i < name.length; i++) {
-      hash = name.charCodeAt(i) + ((hash << 5) - hash)
-    }
-
-    // Generar un color HSL con tonalidad basada en el hash
-    // pero con saturación y luminosidad fijas para mantener colores agradables
-    const hue = hash % 360
-    return `hsl(${hue}, 70%, 85%)`
-  }
 
   return (
     <Card className={`transition-all ${isSelected ? "ring-2 ring-primary" : ""}`}>
@@ -41,7 +28,7 @@ export function LabelCard({ label, onSelect, isSelected = false }: LabelCardProp
         {/* Category Badge Removed */}
         <div
           className="w-full aspect-video rounded-md flex items-center justify-center mt-2 overflow-hidden"
-          style={{ backgroundColor: getBackgroundColor(label.name) }}
+          style={{ backgroundColor: generateColorFromName(label?.name) }}
         >
           <div className="text-center p-4">
             <p className="font-medium text-gray-700">Ejemplo: {label.name}</p>

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -10,3 +10,19 @@ export function cn(...inputs: ClassValue[]) {
 export function safeLength(value?: { length: number } | string | any[]): number {
   return value?.length ?? 0
 }
+
+// Genera un color de fondo HSL a partir de un nombre de forma segura
+export function generateColorFromName(name?: string): string {
+  // Si el nombre no es válido, devolver un color por defecto
+  if (!name || typeof name !== "string" || name.length === 0) {
+    return "hsl(200, 70%, 85%)"
+  }
+
+  let hash = 0
+  for (let i = 0; i < name.length; i++) {
+    hash = name.charCodeAt(i) + ((hash << 5) - hash)
+  }
+
+  const hue = hash % 360
+  return `hsl(${hue}, 70%, 85%)`
+}


### PR DESCRIPTION
## Summary
- add `generateColorFromName` helper
- use helper in `LabelCard` and label detail page
- remove inline color generation logic

## Testing
- `pnpm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a765c7c10832f9f44ccdf8c20e91e